### PR TITLE
v2.2.8.7 - Possible fix for regional Inkbunny issue..

### DIFF
--- a/e621 ReBot v2/Modules/Grabber/Module_Inkbunny.cs
+++ b/e621 ReBot v2/Modules/Grabber/Module_Inkbunny.cs
@@ -120,6 +120,43 @@ namespace e621_ReBot_v2.Modules.Grabber
             ((BackgroundWorker)sender).Dispose();
         }
 
+        public static string InkbunnyURL_Fix(string fix_url)
+        {
+            //E621 may have issues that prevents uploading from direct links coming from Inkbunny servers that require redirecting E621 to another link. This hopefully fixes the issue.
+            //To add other regions when needed, simply copy-paste this entire if-statement, replacing the "br" with the new suffix before the ".ib.metapix.net/" link.
+
+            if (fix_url.Contains("br") && fix_url.Contains(".ib.metapix.net"))
+            {
+                if (!fix_url.Contains("br1") ||
+                    !fix_url.Contains("br2") ||
+                    !fix_url.Contains("br3") ||
+                    !fix_url.Contains("br4"))
+                {
+                    fix_url = fix_url.Replace("br.ib.meta", "jp.ib.meta");
+
+                }
+                else if (fix_url.Contains("br1") && fix_url.Contains(".ib.metapix.net"))
+                {
+                    fix_url = fix_url.Replace("br1.ib.meta", "jp.ib.meta");
+                }
+
+                else if (fix_url.Contains("br2") && fix_url.Contains(".ib.metapix.net"))
+                {
+                    fix_url = fix_url.Replace("br2.ib.meta", "jp.ib.meta");
+                }
+
+                else if (fix_url.Contains("br3") && fix_url.Contains(".ib.metapix.net"))
+                {
+                    fix_url = fix_url.Replace("br3.ib.meta", "jp.ib.meta");
+                }
+
+                else if (fix_url.Contains("br4") && fix_url.Contains(".ib.metapix.net"))
+                {
+                    fix_url = fix_url.Replace("br4.ib.meta", "jp.ib.meta");
+                }
+            }
+            return fix_url;
+        }
         public static string Grab(string WebAdress)
         {
             string HTMLSource = Module_Grabber.GrabPageSource(WebAdress, ref Module_CookieJar.Cookies_Inkbunny);
@@ -172,6 +209,8 @@ namespace e621_ReBot_v2.Modules.Grabber
                         }
                     }
 
+
+                    Post_MediaURL = InkbunnyURL_Fix(Post_MediaURL);
                     DataRow TempDataRow = TempDataTable.NewRow();
                     FillDataRow(ref TempDataRow, Post_URL, Post_Time, Post_Title, Post_Text, Post_MediaURL, ArtistName);
                     TempDataTable.Rows.Add(TempDataRow);
@@ -216,6 +255,7 @@ namespace e621_ReBot_v2.Modules.Grabber
                             if (Module_Grabber.CheckURLExists(MediaLinkFix))
                             {
                                 Post_MediaURL = MediaLinkFix;
+                                Post_MediaURL = InkbunnyURL_Fix(Post_MediaURL);
                                 break;
                             }
                             else
@@ -263,7 +303,7 @@ namespace e621_ReBot_v2.Modules.Grabber
                     if (SkipCounter > 0)
                     {
                         PrintText += $", {SkipCounter} media container{(SkipCounter > 1 ? "s have" : " has")} been skipped";
-                    }              
+                    }
                 }
                 lock (Module_Grabber._GrabQueue_URLs)
                 {

--- a/e621 ReBot v2/Modules/Grabber/Module_Twitter.cs
+++ b/e621 ReBot v2/Modules/Grabber/Module_Twitter.cs
@@ -201,6 +201,10 @@ namespace e621_ReBot_v2.Modules.Grabber
                 Post_Time = DateTime.Parse(PostNode.SelectSingleNode(".//a[@aria-label and @role='link']/time").Attributes["datetime"].Value);
 
                 HtmlNodeCollection ImageNodes = PostNode.SelectNodes(".//div[@data-testid='tweetPhoto']//img[@alt='Image']");
+                if (ImageNodes == null) //Fix for translated twitter HTML. Make it a "While null" loop in case more regions are needed?
+                {
+                    ImageNodes = PostNode.SelectNodes(".//div[@data-testid='tweetPhoto']//img[@alt='Imagem']"); //image -> imagem | Brazilian Portuguese
+                }
                 if (ImageNodes != null)
                 {
                     //twitter carousel displayes them strangely when there's 4. 1-3-2-4 (as html order).

--- a/e621 ReBot v2/Properties/AssemblyInfo.cs
+++ b/e621 ReBot v2/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.8.6")]
+[assembly: AssemblyFileVersion("2.2.8.7")]

--- a/e621 ReBot v2/Properties/AssemblyInfo.cs
+++ b/e621 ReBot v2/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.8.7")]
+[assembly: AssemblyFileVersion("2.2.8.8")]


### PR DESCRIPTION
I had an issue where direct uploading to e621 through reBot resulted in an error, but it was on the e621 side.

My area, Brazil, uses inkbunny links with a "br" prefix, and they may be numbered or not.

Inkbunny can redirect users from "br" to "brX" when needed, but according to Kira on discord, they don't want e621 to follow such redirects.

So I created this function to fix the link before it reaches the e621 image fetcher, so it always uses the already redirected link, in a certain way.

Created it as a function in case there are more regional links with this issue.

In example, when uploading manually, simply changing "...br.ib.metapix.net/..." to "...jp.ib.metapix.net/..." fixed the issue.